### PR TITLE
added acceptance tests and few improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ default: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
-.PHONY: golint
-golint:
+.PHONY: lint
+lint:
 	golangci-lint run
 
 .PHONY: docs

--- a/docs/data-sources/authorization.md
+++ b/docs/data-sources/authorization.md
@@ -46,6 +46,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String) A resource ID. Identifies a specific resource.
+- `name` (String) The name of the resource. Note: not all resource types have a name property.
 - `org` (String) An organization name. The organization that owns the resource.
 - `org_id` (String) An organization ID. Identifies the organization that owns the resource.
 - `type` (String) A resource type. Identifies the API resource's type (or kind).

--- a/docs/data-sources/authorizations.md
+++ b/docs/data-sources/authorizations.md
@@ -50,6 +50,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String) A resource ID. Identifies a specific resource.
+- `name` (String) The name of the resource. Note: not all resource types have a name property.
 - `org` (String) An organization name. The organization that owns the resource.
 - `org_id` (String) An organization ID. Identifies the organization that owns the resource.
 - `type` (String) A resource type. Identifies the API resource's type (or kind).

--- a/docs/resources/authorization.md
+++ b/docs/resources/authorization.md
@@ -23,7 +23,7 @@ Creates and manages an authorization and returns the authorization with the gene
 ### Optional
 
 - `description` (String) A description of the token.
-- `status` (String) Status of the token.
+- `status` (String) Status of the token. Valid values are `active` or `inactive`.
 - `user` (String) A user name. Specifies the user that the authorization is scoped to.
 - `user_id` (String) A user ID. Specifies the user that the authorization is scoped to.
 
@@ -40,7 +40,7 @@ Creates and manages an authorization and returns the authorization with the gene
 
 Required:
 
-- `action` (String) Permission action.
+- `action` (String) Permission action. Valid values are `read` or `write`.
 - `resource` (Attributes) (see [below for nested schema](#nestedatt--permissions--resource))
 
 <a id="nestedatt--permissions--resource"></a>
@@ -52,6 +52,7 @@ Required:
 - `org_id` (String) An organization ID. Identifies the organization that owns the resource.
 - `type` (String) A resource type. Identifies the API resource's type (or kind).
 
-Read-Only:
+Optional:
 
+- `name` (String) The name of the resource. **Note:** not all resource types have a name property.
 - `org` (String) An organization name. The organization that owns the resource.

--- a/docs/resources/bucket.md
+++ b/docs/resources/bucket.md
@@ -17,14 +17,14 @@ Creates and manages a bucket.
 
 ### Required
 
+- `name` (String) A Bucket name.
 - `org_id` (String) An organization ID.
 
 ### Optional
 
 - `description` (String) A description of the bucket.
-- `name` (String) A Bucket name.
-- `retention_period` (Number) The duration in seconds for how long data will be kept in the database. The default duration is 2592000 (30 days). 0 represents infinite retention.
-- `type` (String) The Bucket type.
+- `retention_period` (Number) The duration in seconds for how long data will be kept in the database. The default duration is `2592000` (30 days). `0` represents infinite retention.
+- `type` (String) The Bucket type. Valid values are `user` or `system`.
 
 ### Read-Only
 

--- a/internal/provider/authorization_data_source.go
+++ b/internal/provider/authorization_data_source.go
@@ -96,17 +96,21 @@ func (d *AuthorizationDataSource) Schema(ctx context.Context, req datasource.Sch
 									Computed:    true,
 									Description: "A resource ID. Identifies a specific resource.",
 								},
-								"type": schema.StringAttribute{
+								"name": schema.StringAttribute{
 									Computed:    true,
-									Description: "A resource type. Identifies the API resource's type (or kind).",
+									Description: "The name of the resource. Note: not all resource types have a name property.",
+								},
+								"org": schema.StringAttribute{
+									Computed:    true,
+									Description: "An organization name. The organization that owns the resource.",
 								},
 								"org_id": schema.StringAttribute{
 									Computed:    true,
 									Description: "An organization ID. Identifies the organization that owns the resource.",
 								},
-								"org": schema.StringAttribute{
+								"type": schema.StringAttribute{
 									Computed:    true,
-									Description: "An organization name. The organization that owns the resource.",
+									Description: "A resource type. Identifies the API resource's type (or kind).",
 								},
 							},
 						},
@@ -168,7 +172,7 @@ func (d *AuthorizationDataSource) Read(ctx context.Context, req datasource.ReadR
 	if authorization == nil {
 		resp.Diagnostics.AddError(
 			"Authorization not found",
-			err.Error(),
+			"Authorization not found",
 		)
 
 		return
@@ -180,9 +184,10 @@ func (d *AuthorizationDataSource) Read(ctx context.Context, req datasource.ReadR
 			Action: types.StringValue(string(permissionData.Action)),
 			Resource: AuthorizationPermissionrResourceModel{
 				Id:    types.StringPointerValue(permissionData.Resource.Id),
-				Type:  types.StringValue(string(permissionData.Resource.Type)),
-				OrgID: types.StringPointerValue(permissionData.Resource.OrgID),
+				Name:  types.StringPointerValue(permissionData.Resource.Name),
 				Org:   types.StringPointerValue(permissionData.Resource.Org),
+				OrgID: types.StringPointerValue(permissionData.Resource.OrgID),
+				Type:  types.StringValue(string(permissionData.Resource.Type)),
 			},
 		}
 

--- a/internal/provider/authorization_data_source_test.go
+++ b/internal/provider/authorization_data_source_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAuthorizationDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: providerConfig + testAccAuthorizationDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.influxdb_authorization.test", "permissions.#", "2"),
+					resource.TestCheckResourceAttr("data.influxdb_authorization.test", "description", "Access test bucket"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAuthorizationDataSourceConfig() string {
+	return `
+resource "influxdb_bucket" "test" {
+	name = "test"
+	org_id = "` + os.Getenv("INFLUXDB_ORG_ID") + `"
+  }
+
+resource "influxdb_authorization" "test" {
+	org_id      = "` + os.Getenv("INFLUXDB_ORG_ID") + `"
+	description = "Access test bucket"
+  
+	permissions = [{
+	  action = "read"
+	  resource = {
+		id     = influxdb_bucket.test.id
+		org_id = "` + os.Getenv("INFLUXDB_ORG_ID") + `"
+		type   = "buckets"
+	  }
+	  },
+	  {
+		action = "write"
+		resource = {
+		  id     = influxdb_bucket.test.id
+		  org_id = "` + os.Getenv("INFLUXDB_ORG_ID") + `"
+		  type   = "buckets"
+		}
+	}]
+  }
+
+  data "influxdb_authorization" "test" {
+	id = influxdb_authorization.test.id
+  }
+`
+}

--- a/internal/provider/authorization_model.go
+++ b/internal/provider/authorization_model.go
@@ -26,7 +26,8 @@ type AuthorizationPermissionModel struct {
 // AuthorizationPermissionrResourceModel maps InfluxDB authorization permission resource schema data.
 type AuthorizationPermissionrResourceModel struct {
 	Id    types.String `tfsdk:"id"`
-	Type  types.String `tfsdk:"type"`
-	OrgID types.String `tfsdk:"org_id"`
+	Name  types.String `tfsdk:"name"`
 	Org   types.String `tfsdk:"org"`
+	OrgID types.String `tfsdk:"org_id"`
+	Type  types.String `tfsdk:"type"`
 }

--- a/internal/provider/authorization_resource_test.go
+++ b/internal/provider/authorization_resource_test.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAuthorizationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConfig + testAccAuthorizationResourceConfig("Access test bucket"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("influxdb_authorization.test", "permissions.#", "2"),
+					resource.TestCheckResourceAttr("influxdb_authorization.test", "description", "Access test bucket"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName: "influxdb_authorization.test",
+				ImportState:  true,
+			},
+			// Update and Read testing
+			{
+				Config: providerConfig + testAccAuthorizationResourceConfig("RW access test bucket"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("influxdb_authorization.test", "permissions.#", "2"),
+					resource.TestCheckResourceAttr("influxdb_authorization.test", "description", "RW access test bucket"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccAuthorizationResourceConfig(description string) string {
+	return fmt.Sprintf(`
+resource "influxdb_bucket" "test" {
+	name = "test"
+	org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+  }
+
+resource "influxdb_authorization" "test" {
+	org_id      = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+	description = %[1]q
+  
+	permissions = [{
+	  action = "read"
+	  resource = {
+		id     = influxdb_bucket.test.id
+		org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+		type   = "buckets"
+	  }
+	  },
+	  {
+		action = "write"
+		resource = {
+		  id     = influxdb_bucket.test.id
+		  org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+		  type   = "buckets"
+		}
+	}]
+  }
+`, description)
+}

--- a/internal/provider/authorizations_data_source.go
+++ b/internal/provider/authorizations_data_source.go
@@ -104,17 +104,21 @@ func (d *AuthorizationsDataSource) Schema(ctx context.Context, req datasource.Sc
 												Computed:    true,
 												Description: "A resource ID. Identifies a specific resource.",
 											},
-											"type": schema.StringAttribute{
+											"name": schema.StringAttribute{
 												Computed:    true,
-												Description: "A resource type. Identifies the API resource's type (or kind).",
+												Description: "The name of the resource. Note: not all resource types have a name property.",
+											},
+											"org": schema.StringAttribute{
+												Computed:    true,
+												Description: "An organization name. The organization that owns the resource.",
 											},
 											"org_id": schema.StringAttribute{
 												Computed:    true,
 												Description: "An organization ID. Identifies the organization that owns the resource.",
 											},
-											"org": schema.StringAttribute{
+											"type": schema.StringAttribute{
 												Computed:    true,
-												Description: "An organization name. The organization that owns the resource.",
+												Description: "A resource type. Identifies the API resource's type (or kind).",
 											},
 										},
 									},
@@ -175,9 +179,10 @@ func (d *AuthorizationsDataSource) Read(ctx context.Context, req datasource.Read
 				Action: types.StringValue(string(permissionData.Action)),
 				Resource: AuthorizationPermissionrResourceModel{
 					Id:    types.StringPointerValue(permissionData.Resource.Id),
-					Type:  types.StringValue(string(permissionData.Resource.Type)),
-					OrgID: types.StringPointerValue(permissionData.Resource.OrgID),
+					Name:  types.StringPointerValue(permissionData.Resource.Name),
 					Org:   types.StringPointerValue(permissionData.Resource.Org),
+					OrgID: types.StringPointerValue(permissionData.Resource.OrgID),
+					Type:  types.StringValue(string(permissionData.Resource.Type)),
 				},
 			}
 

--- a/internal/provider/authorizations_data_source_test.go
+++ b/internal/provider/authorizations_data_source_test.go
@@ -1,6 +1,6 @@
 package provider
 
-/* import (
+import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,9 +13,9 @@ func TestAccAuthorizationsDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccAuthorizationsDataSourceConfig,
+				Config: providerConfig + testAccAuthorizationsDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.influxdb_authorizations.all", "", ""),
+					resource.TestCheckResourceAttr("data.influxdb_authorizations.all", "authorizations.#", "1"),
 				),
 			},
 		},
@@ -23,7 +23,5 @@ func TestAccAuthorizationsDataSource(t *testing.T) {
 }
 
 const testAccAuthorizationsDataSourceConfig = `
-data "influxdb_authorizations" "all" {
-}
+data "influxdb_authorizations" "all" {}
 `
-*/

--- a/internal/provider/bucket_data_source_test.go
+++ b/internal/provider/bucket_data_source_test.go
@@ -17,16 +17,17 @@ func TestAccBucketDataSource(t *testing.T) {
 				Config: providerConfig + testAccBucketDataSourceConfig("_monitoring"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.influxdb_bucket.test", "name", "_monitoring"),
+					resource.TestCheckResourceAttr("data.influxdb_bucket.test", "type", "system"),
 				),
 			},
 		},
 	})
 }
 
-func testAccBucketDataSourceConfig(c1 string) string {
+func testAccBucketDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
 data "influxdb_bucket" "test" {
 	name = %[1]q
 }
-`, c1)
+`, name)
 }

--- a/internal/provider/bucket_model.go
+++ b/internal/provider/bucket_model.go
@@ -11,5 +11,5 @@ type BucketModel struct {
 	Name            types.String `tfsdk:"name"`
 	CreatedAt       types.String `tfsdk:"created_at"`
 	UpdatedAt       types.String `tfsdk:"updated_at"`
-	RetentionPeriod types.Int64  `tfsdk:"retention_period"`
+	RetentionPeriod types.Int64  `tfsdk:"retention_period"` // buckets cannot have more than one retention rule at this time
 }

--- a/internal/provider/bucket_resource.go
+++ b/internal/provider/bucket_resource.go
@@ -60,7 +60,7 @@ func (r *BucketResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"type": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
-				Description: "The Bucket type.",
+				Description: "The Bucket type. Valid values are `user` or `system`.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"user", "system"}...),
 				},
@@ -82,11 +82,11 @@ func (r *BucketResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:    true,
 				Description: "Last bucket update date.",
 			},
-			"retention_period": schema.Int64Attribute{
+			"retention_period": schema.Int64Attribute{ // buckets cannot have more than one retention rule at this time
 				Computed:    true,
 				Optional:    true,
 				Default:     int64default.StaticInt64(2592000),
-				Description: "The duration in seconds for how long data will be kept in the database. The default duration is 2592000 (30 days). 0 represents infinite retention.",
+				Description: "The duration in seconds for how long data will be kept in the database. The default duration is `2592000` (30 days). `0` represents infinite retention.",
 			},
 		},
 	}

--- a/internal/provider/bucket_resource_test.go
+++ b/internal/provider/bucket_resource_test.go
@@ -1,7 +1,8 @@
 package provider
 
-/* import (
+import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,29 +15,25 @@ func TestAccBucketResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + testAccBucketResourceConfig("test1", "test bucket", "12c1df6c262377a5"),
+				Config: providerConfig + testAccBucketResourceWithRetentionConfig("test", "test bucket", "0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("influxdb_bucket.test", "name", "test1"),
+					resource.TestCheckResourceAttr("influxdb_bucket.test", "name", "test"),
 					resource.TestCheckResourceAttr("influxdb_bucket.test", "description", "test bucket"),
+					resource.TestCheckResourceAttr("influxdb_bucket.test", "retention_period", "0"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "influxdb_bucket.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// This is not normally necessary, but is here because this
-				// example code does not have an actual upstream service.
-				// Once the Read method is able to refresh information from
-				// the upstream service, this can be removed.
-				ImportStateVerifyIgnore: []string{"id", "defaulted"},
+				ResourceName: "influxdb_bucket.test",
+				ImportState:  true,
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + testAccBucketResourceConfig("test1", "", "12c1df6c262377a5"),
+				Config: providerConfig + testAccBucketResourceConfig("test-bucket", "test-bucket"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("influxdb_bucket.test", "name", "test1"),
-					resource.TestCheckResourceAttr("influxdb_bucket.test", "description", ""),
+					resource.TestCheckResourceAttr("influxdb_bucket.test", "name", "test-bucket"),
+					resource.TestCheckResourceAttr("influxdb_bucket.test", "description", "test-bucket"),
+					resource.TestCheckResourceAttr("influxdb_bucket.test", "retention_period", "2592000"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -44,12 +41,23 @@ func TestAccBucketResource(t *testing.T) {
 	})
 }
 
-func testAccBucketResourceConfig(c1 string, c2 string, c3 string) string {
+func testAccBucketResourceWithRetentionConfig(name string, description string, retention_period string) string {
 	return fmt.Sprintf(`
 resource "influxdb_bucket" "test" {
   name = %[1]q
   description = %[2]q
-  org_id = %[3]q
+  retention_period = %[3]q
+  org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
 }
-`, c1, c2, c3)
-} */
+`, name, description, retention_period)
+}
+
+func testAccBucketResourceConfig(name string, description string) string {
+	return fmt.Sprintf(`
+resource "influxdb_bucket" "test" {
+  name = %[1]q
+  description = %[2]q
+  org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+}
+`, name, description)
+}

--- a/internal/provider/organization_data_source_test.go
+++ b/internal/provider/organization_data_source_test.go
@@ -15,7 +15,8 @@ func TestAccOrganizationDataSource(t *testing.T) {
 			{
 				Config: providerConfig + testAccOrganizationDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.influxdb_organization.default", "name", "default"),
+					resource.TestCheckResourceAttr("data.influxdb_organization.test", "name", "test"),
+					resource.TestCheckResourceAttr("data.influxdb_organization.test", "description", "This is a test organization"),
 				),
 			},
 		},
@@ -23,7 +24,13 @@ func TestAccOrganizationDataSource(t *testing.T) {
 }
 
 const testAccOrganizationDataSourceConfig = `
-data "influxdb_organization" "default" {
-	name = "default"
+resource "influxdb_organization" "test" {
+	name = "test"
+	description = "This is a test organization"
+}
+
+data "influxdb_organization" "test" {
+	name = "test"
+	depends_on = [influxdb_organization.test]
 }
 `

--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -55,6 +55,7 @@ func (r *OrganizationResource) Schema(ctx context.Context, req resource.SchemaRe
 				Description: "The name of the organization.",
 			},
 			"description": schema.StringAttribute{
+				Computed:    true,
 				Optional:    true,
 				Description: "The description of the organization.",
 			},

--- a/internal/provider/organization_resource_test.go
+++ b/internal/provider/organization_resource_test.go
@@ -14,28 +14,23 @@ func TestAccOrganizationResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + testAccOrganizationResourceConfig("test1", "This is a test organization"),
+				Config: providerConfig + testAccOrganizationResourceConfig("test", "This is a test organization"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("influxdb_organization.test", "name", "test1"),
+					resource.TestCheckResourceAttr("influxdb_organization.test", "name", "test"),
 					resource.TestCheckResourceAttr("influxdb_organization.test", "description", "This is a test organization"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "influxdb_organization.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// This is not normally necessary, but is here because this
-				// example code does not have an actual upstream service.
-				// Once the Read method is able to refresh information from
-				// the upstream service, this can be removed.
-				ImportStateVerifyIgnore: []string{"id", "65a453ed2e94b06f"},
+				ResourceName: "influxdb_organization.test",
+				ImportState:  true,
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + testAccOrganizationResourceConfig("test", "test organization"),
+				Config: providerConfig + testAccOrganizationResourceConfig("test2", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("influxdb_organization.test", "name", "test"),
+					resource.TestCheckResourceAttr("influxdb_organization.test", "name", "test2"),
+					resource.TestCheckResourceAttr("influxdb_organization.test", "description", ""),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -43,11 +38,11 @@ func TestAccOrganizationResource(t *testing.T) {
 	})
 }
 
-func testAccOrganizationResourceConfig(c1 string, c2 string) string {
+func testAccOrganizationResourceConfig(name string, description string) string {
 	return fmt.Sprintf(`
 resource "influxdb_organization" "test" {
 	name = %[1]q
 	description = %[2]q
 }
-`, c1, c2)
+`, name, description)
 }

--- a/internal/provider/organizations_data_source_test.go
+++ b/internal/provider/organizations_data_source_test.go
@@ -14,8 +14,7 @@ func TestAccOrganizationsDataSource(t *testing.T) {
 			{
 				Config: providerConfig + testAccOrganizationsDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.influxdb_organizations.all", "organizations.0.name", "default"),
-					resource.TestCheckResourceAttr("data.influxdb_organizations.all", "organizations.0.description", ""),
+					resource.TestCheckResourceAttr("data.influxdb_organizations.all", "organizations.#", "1"),
 				),
 			},
 		},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -10,8 +11,6 @@ import (
 const (
 	// providerConfig is a shared configuration to combine with the actual
 	// test configuration so the HashiCups client is properly configured.
-	// It is also possible to use the HASHICUPS_ environment variables instead,
-	// such as updating the Makefile and running the testing through that tool.
 	providerConfig = `
   provider "influxdb" {}
   `
@@ -26,7 +25,13 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
+	if v := os.Getenv("INFLUXDB_URL"); v == "" {
+		t.Fatal("INFLUXDB_URL must be set for acceptance tests")
+	}
+	if v := os.Getenv("INFLUXDB_TOKEN"); v == "" {
+		t.Fatal("INFLUXDB_TOKEN must be set for acceptance tests")
+	}
+	if v := os.Getenv("INFLUXDB_ORG_ID"); v == "" {
+		t.Fatal("INFLUXDB_ORG_ID must be set for acceptance tests")
+	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

1. Added acceptance tests for all resources and data sources
2. Added `name` field to Authorization resource & data source


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
% make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       terraform-provider-influxdb     [no test files]
=== RUN   TestAccAuthorizationDataSource
--- PASS: TestAccAuthorizationDataSource (1.20s)
=== RUN   TestAccAuthorizationResource
--- PASS: TestAccAuthorizationResource (1.64s)
=== RUN   TestAccAuthorizationsDataSource
--- PASS: TestAccAuthorizationsDataSource (0.64s)
=== RUN   TestAccBucketDataSource
--- PASS: TestAccBucketDataSource (0.56s)
=== RUN   TestAccBucketResource
--- PASS: TestAccBucketResource (1.51s)
=== RUN   TestAccBucketsDataSource
--- PASS: TestAccBucketsDataSource (0.58s)
=== RUN   TestAccOrganizationDataSource
--- PASS: TestAccOrganizationDataSource (0.98s)
=== RUN   TestAccOrganizationResource
--- PASS: TestAccOrganizationResource (1.61s)
=== RUN   TestAccOrganizationsDataSource
--- PASS: TestAccOrganizationsDataSource (0.56s)
PASS
ok      terraform-provider-influxdb/internal/provider   9.581s
...
```
