### PR TITLE
fixed overwriting the token value during read

### DIFF
--- a/docs/resources/authorization.md
+++ b/docs/resources/authorization.md
@@ -48,13 +48,13 @@ Required:
 
 Required:
 
+- `org_id` (String) An organization ID. Identifies the organization that owns the resource.
 - `type` (String) A resource type. Identifies the API resource's type (or kind).
 
 Optional:
 
 - `id` (String) A resource ID. Identifies a specific resource.
 - `org` (String) An organization name. The organization that owns the resource.
-- `org_id` (String) An organization ID. Identifies the organization that owns the resource.
 
 Read-Only:
 

--- a/examples/resources/authorization/resource.tf
+++ b/examples/resources/authorization/resource.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    influxdb = {
+      source = "komminarlabs/influxdb"
+    }
+  }
+}
+
 provider "influxdb" {}
 
 data "influxdb_organization" "iot" {
@@ -15,15 +23,17 @@ resource "influxdb_authorization" "signals" {
   permissions = [{
     action = "read"
     resource = {
-      id   = data.influxdb_bucket.signals.id
-      type = "buckets"
+      id     = data.influxdb_bucket.signals.id
+      org_id = data.influxdb_organization.iot.id
+      type   = "buckets"
     }
     },
     {
       action = "write"
       resource = {
-        id   = data.influxdb_bucket.signals.id
-        type = "buckets"
+        id     = data.influxdb_bucket.signals.id
+        org_id = data.influxdb_organization.iot.id
+        type   = "buckets"
       }
   }]
 }

--- a/examples/resources/bucket/resource.tf
+++ b/examples/resources/bucket/resource.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    influxdb = {
+      source = "komminarlabs/influxdb"
+    }
+  }
+}
+
 provider "influxdb" {}
 
 data "influxdb_organization" "iot" {

--- a/examples/resources/organization/resource.tf
+++ b/examples/resources/organization/resource.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    influxdb = {
+      source = "komminarlabs/influxdb"
+    }
+  }
+}
+
 provider "influxdb" {}
 
 resource "influxdb_organization" "iot" {

--- a/internal/provider/authorization_resource.go
+++ b/internal/provider/authorization_resource.go
@@ -59,6 +59,9 @@ func (r *AuthorizationResource) Schema(ctx context.Context, req resource.SchemaR
 				Computed:    true,
 				Description: "The API token.",
 				Sensitive:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"status": schema.StringAttribute{
 				Optional:    true,
@@ -142,12 +145,8 @@ func (r *AuthorizationResource) Schema(ctx context.Context, req resource.SchemaR
 									},
 								},
 								"org_id": schema.StringAttribute{
-									Computed:    true,
-									Optional:    true,
+									Required:    true,
 									Description: "An organization ID. Identifies the organization that owns the resource.",
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 								"type": schema.StringAttribute{
 									Required:    true,
@@ -300,7 +299,6 @@ func (r *AuthorizationResource) Read(ctx context.Context, req resource.ReadReque
 	state.Id = types.StringPointerValue(authorization.Id)
 	state.Org = types.StringPointerValue(authorization.Org)
 	state.OrgID = types.StringPointerValue(authorization.OrgID)
-	state.Token = types.StringPointerValue(authorization.Token)
 	state.CreatedAt = types.StringValue(authorization.CreatedAt.String())
 	state.UpdatedAt = types.StringValue(authorization.UpdatedAt.String())
 	state.Description = types.StringValue(*authorization.AuthorizationUpdateRequest.Description)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

InfluxDB OSS always returns the token value using the GET operation but InfluxDB cloud returns string `redacted` for the same GET operation. This made the provider to overwrite the actual token in the state. Fixed this by adding token to state only during create and used `UseStateForUnknown` planModifier instead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc

...
```
