### PR TITLE
feat: add dual authentication support with improved validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,24 @@ terraform {
 }
 ```
 
-Initialize the provider
+### Initialize the provider
+
+#### Token-based authentication
 
 ```terraform
 provider "influxdb" {
   url   = "http://localhost:8086"
   token = "influxdb-token"
+}
+```
+
+#### Username and password authentication
+
+```terraform
+provider "influxdb" {
+  url      = "http://localhost:8086"
+  username = "influxdb-user"
+  password = "influxdb-password"
 }
 ```
 
@@ -88,6 +100,15 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 To generate or update documentation, run `make docs`.
+
+## Running Tests
+
+Set the below environment variables to run the tests:
+
+1. `INFLUXDB_URL`
+2. `INFLUXDB_TOKEN` (for token-based authentication)
+3. `INFLUXDB_USERNAME` and `INFLUXDB_PASSWORD` (for username/password authentication)
+4. `INFLUXDB_ORG` (the organization to use for the tests)
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,21 @@ Use the InfluxDB provider to deploy and manage resources supported by InfluxDB. 
 * [InfluxDB Cloud TSM](https://docs.influxdata.com/influxdb/cloud/)
 * [InfluxDB OSS](https://docs.influxdata.com/influxdb/v2/)
 
+## Authentication
+
+The InfluxDB provider supports two [authentication methods](https://docs.influxdata.com/influxdb/v2/api/v2/#tag/Authentication):
+
+* Token-based authentication (recommended).
+* Username and password authentication.
+
+### Authentication Priority
+
+When both authentication methods are provided, **token authentication takes priority**. This means:
+
+- If both `token` and `username`/`password` are configured, the provider will use token authentication
+- Token authentication is the recommended method for better security and simplicity
+- Username/password authentication is used only when no token is provided
+
 ## Example Usage
 
 ```terraform
@@ -37,13 +52,27 @@ provider "influxdb" {}
 
 ## Environment Variables
 
-Credentials can be provided by using the `INFLUXDB_URL` and `INFLUXDB_TOKEN`.
+Credentials can be provided by using the `INFLUXDB_URL`, `INFLUXDB_TOKEN`, `INFLUXDB_USERNAME`, and `INFLUXDB_PASSWORD`.
 
 ### Example
+
+#### Token-based authentication
 
 ```terraform
 export INFLUXDB_URL="http://localhost:8086"
 export INFLUXDB_TOKEN="influxdb-token"
+
+provider "influxdb" {}
+
+terraform plan
+```
+
+#### Username and password authentication
+
+```terraform
+export INFLUXDB_URL="http://localhost:8086"
+export INFLUXDB_USERNAME="influxdb-user"
+export INFLUXDB_PASSWORD="influxdb-password"
 
 provider "influxdb" {}
 
@@ -55,5 +84,7 @@ terraform plan
 
 ### Optional
 
+- `password` (String, Sensitive) The InfluxDB password
 - `token` (String, Sensitive) An InfluxDB token string
 - `url` (String) The InfluxDB Cloud Dedicated server URL
+- `username` (String) The InfluxDB username

--- a/internal/provider/authorization_resource_test.go
+++ b/internal/provider/authorization_resource_test.go
@@ -49,19 +49,21 @@ resource "influxdb_bucket" "test" {
 resource "influxdb_authorization" "test" {
 	org_id      = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
 	description = %[1]q
-  
+
 	permissions = [{
 	  action = "read"
 	  resource = {
-		id   = influxdb_bucket.test.id
-		type = "buckets"
+	  	org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+		id     = influxdb_bucket.test.id
+		type   = "buckets"
 	  }
 	  },
 	  {
 		action = "write"
 		resource = {
-		  id   = influxdb_bucket.test.id
-		  type = "buckets"
+		  org_id = "`+os.Getenv("INFLUXDB_ORG_ID")+`"
+		  id     = influxdb_bucket.test.id
+		  type   = "buckets"
 		}
 	}]
   }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -28,9 +28,20 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("INFLUXDB_URL"); v == "" {
 		t.Fatal("INFLUXDB_URL must be set for acceptance tests")
 	}
-	if v := os.Getenv("INFLUXDB_TOKEN"); v == "" {
-		t.Fatal("INFLUXDB_TOKEN must be set for acceptance tests")
+
+	// Check for authentication credentials - either token OR username+password
+	token := os.Getenv("INFLUXDB_TOKEN")
+	username := os.Getenv("INFLUXDB_USERNAME")
+	password := os.Getenv("INFLUXDB_PASSWORD")
+
+	hasToken := token != ""
+	hasUsernamePassword := username != "" && password != ""
+
+	if !hasToken && !hasUsernamePassword {
+		t.Fatal("Authentication credentials must be set for acceptance tests. " +
+			"Provide either INFLUXDB_TOKEN or both INFLUXDB_USERNAME and INFLUXDB_PASSWORD environment variables")
 	}
+
 	if v := os.Getenv("INFLUXDB_ORG_ID"); v == "" {
 		t.Fatal("INFLUXDB_ORG_ID must be set for acceptance tests")
 	}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -21,19 +21,48 @@ Use the InfluxDB provider to deploy and manage resources supported by InfluxDB. 
 * [InfluxDB Cloud TSM](https://docs.influxdata.com/influxdb/cloud/)
 * [InfluxDB OSS](https://docs.influxdata.com/influxdb/v2/)
 
+## Authentication
+
+The InfluxDB provider supports two [authentication methods](https://docs.influxdata.com/influxdb/v2/api/v2/#tag/Authentication):
+
+* Token-based authentication (recommended).
+* Username and password authentication.
+
+### Authentication Priority
+
+When both authentication methods are provided, **token authentication takes priority**. This means:
+
+- If both `token` and `username`/`password` are configured, the provider will use token authentication
+- Token authentication is the recommended method for better security and simplicity
+- Username/password authentication is used only when no token is provided
+
 ## Example Usage
 
 {{tffile "examples/provider/provider.tf"}}
 
 ## Environment Variables
 
-Credentials can be provided by using the `INFLUXDB_URL` and `INFLUXDB_TOKEN`.
+Credentials can be provided by using the `INFLUXDB_URL`, `INFLUXDB_TOKEN`, `INFLUXDB_USERNAME`, and `INFLUXDB_PASSWORD`.
 
 ### Example
+
+#### Token-based authentication
 
 ```terraform
 export INFLUXDB_URL="http://localhost:8086"
 export INFLUXDB_TOKEN="influxdb-token"
+
+provider "influxdb" {}
+
+terraform plan
+```
+
+#### Username and password authentication
+
+```terraform
+export INFLUXDB_URL="http://localhost:8086"
+export INFLUXDB_USERNAME="influxdb-user"
+export INFLUXDB_PASSWORD="influxdb-password"
 
 provider "influxdb" {}
 


### PR DESCRIPTION
### Description

Introduces support for username and password based login. While it is not recommended when the AWS Timestream service creates an InfluxDB instance it generates a Secret in AWS Secrets Manager containing a username and password (and initial token and bucket but those are not relevant).

Currently there is no way to manage any InfluxDB resources with Terraform. With this patch the provider can fetch the values from AWS Secrets Manager and authenticate using the username and password.

### Relations
I did not create an issue yet, as first I wanted to make sure that the method actually works.

### References
We use the [aws_timestreaminfluxdb_db_instance](https://registry.terraform.io/providers/hashicorp/aws/5.99.1/docs/resources/timestreaminfluxdb_db_instance) to create the InfluxDB instance.

Check the `influx_auth_parameters_secret_arn` attribute for the details. Please note that the Secret is created by AWS not the AWS Terraform provider, so we don't have any control over the contents.

### Output from Acceptance Testing
Sorry but `make testacc` just fails with or without this change on my machine. If you can provide any guide on the requirements then I'll try to make it work.

### NOTE
Please note that this is just the core of the change. I created this so we can discuss if the feature is acceptable by you or not. If yes then I will update the documentation accordingly and update this PR.

Also if needed I will create an issue which then can be linked to this PR.
