### PR TITLE
fix: Remove validator for duplicate permissions in authorization reso…

### DIFF
--- a/internal/provider/authorization_resource.go
+++ b/internal/provider/authorization_resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -110,9 +109,6 @@ func (r *AuthorizationResource) Schema(ctx context.Context, req resource.SchemaR
 			"permissions": schema.ListNestedAttribute{
 				Required:    true,
 				Description: "A list of permissions for an authorization.",
-				Validators: []validator.List{
-					listvalidator.UniqueValues(),
-				},
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The previous validator was problematic because:

- It incorrectly flagged different resource references as duplicates when resource IDs were unknown during the plan phase
- It added complexity that didn't align with actual API behavior
- It caused false positives for valid configurations with multiple distinct resources

Since the API gracefully handles duplicates server-side, removing this validation simplifies the provider while maintaining correct functionality.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #86 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/komminarlabs/terraform-provider-influxdb     [no test files]
=== RUN   TestAccAuthorizationDataSource
--- PASS: TestAccAuthorizationDataSource (0.68s)
=== RUN   TestAccAuthorizationResource
--- PASS: TestAccAuthorizationResource (0.86s)
=== RUN   TestAccAuthorizationsDataSource
--- PASS: TestAccAuthorizationsDataSource (0.37s)
=== RUN   TestAccBucketDataSource
--- PASS: TestAccBucketDataSource (0.34s)
=== RUN   TestAccBucketResource
--- PASS: TestAccBucketResource (0.79s)
=== RUN   TestAccBucketsDataSource
--- PASS: TestAccBucketsDataSource (0.33s)
=== RUN   TestAccLabelDataSource
--- PASS: TestAccLabelDataSource (0.43s)
=== RUN   TestAccLabelDataSourceWithProperties
--- PASS: TestAccLabelDataSourceWithProperties (0.38s)
=== RUN   TestAccLabelResource
--- PASS: TestAccLabelResource (0.74s)
=== RUN   TestAccLabelResourceWithProperties
--- PASS: TestAccLabelResourceWithProperties (0.90s)
=== RUN   TestAccLabelResourcePropertyRemoval
--- PASS: TestAccLabelResourcePropertyRemoval (0.63s)
=== RUN   TestAccLabelsDataSource
--- PASS: TestAccLabelsDataSource (0.42s)
=== RUN   TestAccLabelsDataSourceWithProperties
--- PASS: TestAccLabelsDataSourceWithProperties (0.44s)
=== RUN   TestAccOrganizationDataSource
--- PASS: TestAccOrganizationDataSource (0.49s)
=== RUN   TestAccOrganizationResource
--- PASS: TestAccOrganizationResource (0.86s)
=== RUN   TestAccOrganizationsDataSource
--- PASS: TestAccOrganizationsDataSource (0.34s)
=== RUN   TestAccTaskDataSource
--- PASS: TestAccTaskDataSource (0.41s)
=== RUN   TestAccTaskResource
--- PASS: TestAccTaskResource (0.68s)
=== RUN   TestAccTaskResourceValidation
--- PASS: TestAccTaskResourceValidation (0.40s)
=== RUN   TestAccTasksDataSource
--- PASS: TestAccTasksDataSource (0.41s)
=== RUN   TestAccTasksDataSourceWithMultipleTasks
--- PASS: TestAccTasksDataSourceWithMultipleTasks (0.44s)
=== RUN   TestAccUserDataSource
--- PASS: TestAccUserDataSource (0.47s)
=== RUN   TestAccUserDataSourceWithOrganization
--- PASS: TestAccUserDataSourceWithOrganization (0.62s)
=== RUN   TestAccUserDataSourceNonExistent
--- PASS: TestAccUserDataSourceNonExistent (0.13s)
=== RUN   TestAccUserResource
--- PASS: TestAccUserResource (0.89s)
=== RUN   TestAccUserResourceWithOrganization
--- PASS: TestAccUserResourceWithOrganization (1.13s)
=== RUN   TestAccUserResourceOrgSwitching
--- PASS: TestAccUserResourceOrgSwitching (1.49s)
=== RUN   TestAccUserResourceValidation
--- PASS: TestAccUserResourceValidation (0.74s)
=== RUN   TestAccUserResourceRoleChange
--- PASS: TestAccUserResourceRoleChange (1.18s)
=== RUN   TestAccUsersDataSource
--- PASS: TestAccUsersDataSource (0.53s)
=== RUN   TestAccUsersDataSourceWithOrganizations
--- PASS: TestAccUsersDataSourceWithOrganizations (0.87s)
=== RUN   TestAccUsersDataSourceEmpty
--- PASS: TestAccUsersDataSourceEmpty (0.35s)
PASS
ok      github.com/komminarlabs/terraform-provider-influxdb/internal/provider   (cached)
...
```
